### PR TITLE
Use str_slug() to generate post slug

### DIFF
--- a/app/Console/Commands/PostMakeCommand.php
+++ b/app/Console/Commands/PostMakeCommand.php
@@ -29,7 +29,7 @@ class PostMakeCommand extends Command
     public function handle()
     {
         $title = $this->input->getArgument('title');
-        $slug = strtolower(str_replace(' ', '-', $title));
+        $slug = strtolower(str_slug($title));
         $date = Carbon::now();
         $type = $this->input->getOption('external') ? 'external' : 'article';
 


### PR DESCRIPTION
This [takes care of a couple more edge-cases](https://github.com/illuminate/support/blob/master/Str.php#L383) that you probably won't run into, but ¯\\\_(ツ)_/¯