### PR TITLE
Fix small syntax error in code-splitting post

### DIFF
--- a/posts/2018-04-16.code-splitting-with-laravel-mix.md
+++ b/posts/2018-04-16.code-splitting-with-laravel-mix.md
@@ -132,7 +132,7 @@ Judging by the bundle sizes, we've split our scripts as expected.
 Unfortunately `0.js` is a pretty vague file name. Webpack can't predict chunk names, but we can define it ourselves with a _magic comment_.
 
 ```js
-import('./initMyBigFatComponent' /* webpackChunkName: "/js/my-component" */)
+import('./initMyBigFatComponent' /* webpackChunkName: "js/my-component" */)
     .then(initMyBigFatComponent => {
         // ...
     });


### PR DESCRIPTION
I removed the leading `/` from the `webpackChunkName`, two reasons:

1. It'll match the source that you distribute with the article (see: https://github.com/sebastiandedeyne/code-splitting-with-laravel-mix/blob/master/resources/assets/js/app.js#L6)
2. it doesn't work with the `/`. I haven't check deep enough, but it seemds that webpack (or Mix) add a leading `/` no matter what, thus resulting in the browser trying to load `//js/my-component.js` instead of `/js/my-component.js`

---

Great articel by the way!