### PR TITLE
chore: mention Vue 2 plugin

### DIFF
--- a/content/posts/vite-with-laravel/vue.md
+++ b/content/posts/vite-with-laravel/vue.md
@@ -15,9 +15,7 @@ summary: |
   How to set up Vue.js in Vite with Laravel.
 ---
 
-*At the time of writing, Vite isn't compatible with Vue 2. This guide is written for Vue 3.*
-
-To transpile Vue single-file components, install `@vitejs/plugin-vue`.
+To transpile Vue single-file components, install [`@vitejs/plugin-vue`](https://github.com/vitejs/vite/tree/main/packages/plugin-vue). If you are using Vue 2, install [`vite-plugin-vue2`](https://github.com/underfin/vite-plugin-vue2) instead.
 
 ```json {hl_lines=["8", "12"]}
 {


### PR DESCRIPTION
Vue 2 is actually supported thanks to https://github.com/underfin/vite-plugin-vue2, so this PR makes changes to reflect it. Wasn't too sure of the wording, but I didn't want to open an issue, so I still PR'd.